### PR TITLE
Fixing emoji deletion for custom emoji

### DIFF
--- a/src/rest/crud/reaction.jl
+++ b/src/rest/crud/reaction.jl
@@ -21,4 +21,7 @@ function delete(c::Client, emoji::StringOrChar, m::Message, u::User)
         delete_user_reaction(c, m.channel_id, m.id, emoji, u.id)
     end
 end
-delete(c::Client, e::Emoji, m::Message, u::User) = delete(c, e.name, m, u)
+function delete(c::Client, e::Emoji, m::Message, u::User)
+    emoji = e.id === nothing ? e.name : "$(e.name):$(e.id)"
+    delete(c, emoji, m, u)
+end


### PR DESCRIPTION
What have you changed?

* [ ] Added a new feature
* [X] Fixed a reported issue (discussed in Discord)
* [ ] Updated documentation

---

Fixing the deletion of custom emoji.

There's a slight issue that users could still mis-use the `emoji::StringOrChar` method by passing in `emoji.name` when dealing with custom emoji. I wonder if this should be mentioned in the documentation at all?
