### PR TITLE
Refresh list of channel types

### DIFF
--- a/src/types/channel.jl
+++ b/src/types/channel.jl
@@ -12,9 +12,9 @@ at https://discord.com/developers/docs/resources/channel#channel-object-channel-
     CT_GUILD_CATEGORY=4
     CT_GUILD_NEWS=5
     CT_GUILD_STORE=6
-    UNUSED_API_V9_1=7
-    UNUSED_API_V9_2=8
-    UNUSED_API_V9_3=9
+    CT_UNUSED_API_V9_1=7
+    CT_UNUSED_API_V9_2=8
+    CT_UNUSED_API_V9_3=9
     CT_GUILD_NEWS_THREAD=10
     CT_GUILD_PUBLIC_THREAD=11
     CT_GUILD_PRIVATE_THREAD=12


### PR DESCRIPTION
This PR just updates the list of enums for ChannelType.
See full list at https://discord.com/developers/docs/resources/channel#channel-object-channel-types

Why? I started getting the following error today and by just updating the enums the problem is gone.
```
┌ Error: Parsing failed
│   time = 2021-10-09T22:59:34.187
│   conn = 1
│   T = Discord.GuildCreate
│   data =
│    Dict{Symbol, Any} with 49 entries:
│      :premium_progress_bar_enabled => false
│      ⋮                             => ⋮
│   exception =
│    ArgumentError: invalid value for Enum ChannelType: 13
│    Stacktrace:
│      [1] enum_argument_error(typename::Symbol, x::Int64)
│        @ Base.Enums ./Enums.jl:79
│      [2] ChannelType
│        @ ./Enums.jl:192 [inlined]
│      [3] Discord.DiscordChannel(; kwargs::Base.Iterators.Pairs{Symbol, Any, NTuple{11, Symbol}, NamedTuple{(:position, :parent_id, :user_limit, :rtc_region, :name, :topic, :nsfw, :permission_overwrites, :type, :id, :bitrate), Tuple{Int64, String, Int64, Nothing, String, Nothing, Bool, Vector{Any}, Int64, String, Int64}}})
│        @ Discord ~/.julia/packages/Discord/3wJXG/src/types/types.jl:97
│      [4] Discord.DiscordChannel(d::Dict{Symbol, Any})
│        @ Discord ~/.julia/packages/Discord/3wJXG/src/types/types.jl:98
```

